### PR TITLE
feat(gpu-tuning): add frequency lock status UI and improve state mana…

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1045,6 +1045,9 @@
     <string name="material_gpu_mali">MALI</string>
     <string name="material_gpu_powervr">POWERVR</string>
     <string name="material_gpu_unknown">GPU Tidak Dikenal</string>
+    <string name="material_gpu_frequency_lock">Kunci Frekuensi GPU</string>
+    <string name="material_gpu_lock_frequency">Kunci Frekuensi</string>
+    <string name="material_gpu_unlock_frequency">Buka Kunci Frekuensi</string>
     
     <!-- Material Tuning Strings -->
     <string name="material_tuning_title">Tuning</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1232,6 +1232,9 @@
     <string name="material_gpu_mali">MALI</string>
     <string name="material_gpu_powervr">POWERVR</string>
     <string name="material_gpu_unknown">Unknown GPU</string>
+    <string name="material_gpu_frequency_lock">GPU Frequency Lock</string>
+    <string name="material_gpu_lock_frequency">Lock Frequency</string>
+    <string name="material_gpu_unlock_frequency">Unlock Frequency</string>
     
     <!-- Material Tuning Strings -->
     <string name="material_tuning_title">Tuning</string>


### PR DESCRIPTION
…gement

- Add lock status badge with animated visibility and icon indicators
- Import additional Compose animation utilities (fadeIn, fadeOut, scaleIn, scaleOut)
- Import Lock and LockOpen material icons for frequency lock state visualization
- Update GPU frequency selection to use locked values when available
- Enhance state management by tracking lockedMinFreq and lockedMaxFreq from ViewModel
- Wrap frequency controls in Surface container with improved visual hierarchy
- Add header section with lock status badge showing locked/unlocked state